### PR TITLE
Fix/tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nexient-llc/tf-aws-wrapper_module-dns_zone.git
+module github.com/nexient-llc/tf-aws-wrapper_module-dns_zone
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/nexient-llc/tf-aws-wrapper_module-dns_zone
+module github.com/nexient-llc/tf-aws-collection_module-dns_zone
 
 go 1.20
 
 require (
 	github.com/gruntwork-io/terratest v0.43.12
-	github.com/nexient-llc/tf-caf-terratest-common v0.0.0-20230825182020-c6ffde8a1ec0
+	github.com/nexient-llc/lcaf-component-terratest-common v0.0.0-20240117163707-a1dfafae58b4
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nexient-llc/tf-caf-terratest-common v0.0.0-20230825182020-c6ffde8a1ec0 h1:cixbsDwd239Wc8iZ1YEZPjLR3mEWY8hrvtb3uxNGjuw=
-github.com/nexient-llc/tf-caf-terratest-common v0.0.0-20230825182020-c6ffde8a1ec0/go.mod h1:m/nIPmz5ptmPeQoVuLP7OasfVvvEVvIz/+7KibgRvDE=
+github.com/nexient-llc/lcaf-component-terratest-common v0.0.0-20240117163707-a1dfafae58b4 h1:d159w/9sreYb3dJg+s1XGO0bIr00JtjrdgJf6z7eCnI=
+github.com/nexient-llc/lcaf-component-terratest-common v0.0.0-20240117163707-a1dfafae58b4/go.mod h1:g3lD3RGQNlbd66ngNJnxA7hjjfEL+YAEksN0nxK9Ddc=
 github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/post_deploy_functional/main_test.go
+++ b/tests/post_deploy_functional/main_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	"testing"
 
+	"github.com/nexient-llc/lcaf-component-terratest-common/lib"
+	"github.com/nexient-llc/lcaf-component-terratest-common/types"
 	testimpl "github.com/nexient-llc/tf-aws-collection_module-dns_zone/tests/testimpl"
-	"github.com/nexient-llc/tf-caf-terratest-common/lib"
-	"github.com/nexient-llc/tf-caf-terratest-common/types"
 )
 
 const (

--- a/tests/post_deploy_functional_readonly/main_readonly_test.go
+++ b/tests/post_deploy_functional_readonly/main_readonly_test.go
@@ -5,8 +5,8 @@ import (
 
 	testimpl "github.com/nexient-llc/tf-aws-collection_module-dns_zone/tests/testimpl"
 
-	"github.com/nexient-llc/tf-caf-terratest-common/lib"
-	"github.com/nexient-llc/tf-caf-terratest-common/types"
+	"github.com/nexient-llc/lcaf-component-terratest-common/lib"
+	"github.com/nexient-llc/lcaf-component-terratest-common/types"
 )
 
 const (

--- a/tests/testimpl/test_impl.go
+++ b/tests/testimpl/test_impl.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/nexient-llc/tf-caf-terratest-common/lib/aws/dns"
-	"github.com/nexient-llc/tf-caf-terratest-common/types"
+	"github.com/nexient-llc/lcaf-component-terratest-common/lib/aws/dns"
+	"github.com/nexient-llc/lcaf-component-terratest-common/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/testimpl/types.go
+++ b/tests/testimpl/types.go
@@ -1,6 +1,6 @@
 package common
 
-import "github.com/nexient-llc/tf-caf-terratest-common/types"
+import "github.com/nexient-llc/lcaf-component-terratest-common/types"
 
 type ThisTFModuleConfig struct {
 	types.GenericTFModuleConfig

--- a/variables.tf
+++ b/variables.tf
@@ -44,18 +44,21 @@ variable "environment_number" {
   description = "The environment count for the respective environment. Defaults to 000. Increments in value of 1"
   type        = string
   default     = "000"
+  type        = string
 }
 
 variable "resource_number" {
   description = "The resource count for the respective resource. Defaults to 000. Increments in value of 1"
   type        = string
   default     = "000"
+  type        = string
 }
 
 variable "region" {
   description = "AWS Region in which the infra needs to be provisioned"
   type        = string
   default     = "us-east-2"
+  type        = string
 }
 
 variable "logical_product_family" {


### PR DESCRIPTION
Migrates terratest to renamed CAF component, fixes failures identified by `make go/lint`